### PR TITLE
Fix crash on launch "GPU process isn't usable"

### DIFF
--- a/.electron-vue/dev-runner.js
+++ b/.electron-vue/dev-runner.js
@@ -139,7 +139,8 @@ function startElectron () {
   var args = [
     '--inspect=5858',
     '--developer',
-    path.join(__dirname, '../dist/electron/main.js')
+    path.join(__dirname, '../dist/electron/main.js'),
+    '--in-process-gpu'
   ]
 
   // detect yarn or npm and process commandline args accordingly

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -20,7 +20,7 @@ ipcMain.handle('updateTitle', (event, data) => {
 })
 
 global.debugMode = app.commandLine.hasSwitch('developer')
-
+app.commandLine.appendSwitch('in-process-gpu')
 let customURL_enable = app.commandLine.hasSwitch('url')
 let customURL = app.commandLine.getSwitchValue('url')
 


### PR DESCRIPTION
Fixes issue #13 

Append `--in-process-gpu` to command line to fix.